### PR TITLE
楽曲URLと座標を登録する機能追加

### DIFF
--- a/app/controllers/coordinate_controller.rb
+++ b/app/controllers/coordinate_controller.rb
@@ -4,6 +4,11 @@ class CoordinateController < ApplicationController
         @coodinates_in_area = Coordinate.near([coordinate_params["latitude"], coordinate_params["longitude"]], 5, units: :km)
     end
 
+    def create
+      @coordinate = Coordinate.new(coordinate_params)
+      @coordinate.save
+    end
+
     private
     def coordinate_params
       params.permit(:latitude, :longitude)

--- a/app/controllers/song_controller.rb
+++ b/app/controllers/song_controller.rb
@@ -2,4 +2,23 @@ class SongController < ApplicationController
     def index
         @songs = Song.all
     end
+
+    def create
+        @song = Song.new(song_params)
+        @song.platform = 1 # Platform id of youtube
+        # TODO: Get coordinate value from the form
+        coordinate = Coordinate.new(latitude: 50, longitude: 50)
+        @song.coordinate << coordinate
+        if @song.save
+            redirect_to "/"
+        else
+            redirect_to "/register"
+        end
+    end
+
+    private
+    def song_params
+      params.permit(:url)
+    end
+
 end

--- a/app/controllers/song_controller.rb
+++ b/app/controllers/song_controller.rb
@@ -10,6 +10,7 @@ class SongController < ApplicationController
         coordinate = Coordinate.new(latitude: 50, longitude: 50)
         @song.coordinate << coordinate
         if @song.save
+            flash[:success] = "Your song registration successfully"
             redirect_to "/"
         else
             redirect_to "/register"

--- a/app/models/coordinate.rb
+++ b/app/models/coordinate.rb
@@ -9,6 +9,8 @@
 #  updated_at :datetime         not null
 #
 class Coordinate < ApplicationRecord
+    has_many :coordinate_songs
+    has_many :song, through: :coordinate_songs
     # Config for geocoder
     geocoded_by latitude: :latitude, longitude: :longitude
 end

--- a/app/models/coordinate_song.rb
+++ b/app/models/coordinate_song.rb
@@ -19,4 +19,6 @@
 #  fk_rails_...  (song_id => songs.id)
 #
 class CoordinateSong < ApplicationRecord
+    belongs_to :coordinate
+    belongs_to :song
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -9,4 +9,6 @@
 #  updated_at :datetime         not null
 #
 class Song < ApplicationRecord
+    has_many :coordinate_songs
+    has_many :coordinate, through: :coordinate_songs
 end

--- a/app/views/coordinate/find.html.erb
+++ b/app/views/coordinate/find.html.erb
@@ -2,9 +2,17 @@
 
 <ul>
   <% @coodinates_in_area.each do |point| %>
-  <h3>Point</h3>
+    <h3>Point</h3>
 
-  <p>Latitude: <%= point.latitude %></p>
-  <p>Longitude: <%= point.longitude %></p>
+    <p>Latitude: <%= point.latitude %></p>
+    <p>Longitude: <%= point.longitude %></p>
+    <% if point.song.collect(&:url)[0] %>
+      <p>Youtube: <%= link_to point.song.collect(&:url)[0], point.song.collect(&:url)[0] %></p>
+    <% else %>
+      <p> No Youtube URL </p>
+    <% end %>
+  
   <% end %>
 </ul>
+
+<%= link_to "Back to home", "/" %>

--- a/app/views/song/index.html.erb
+++ b/app/views/song/index.html.erb
@@ -3,7 +3,10 @@
 <ul>
   <% @songs.each do |song| %>
     <li>
-      <%= song.url %>
+    <%= song.id %>
+    <%= link_to song.url, song.url %>
     </li>
   <% end %>
 </ul>
+
+<%= link_to "Back to home", "/" %>

--- a/app/views/song/register.html.erb
+++ b/app/views/song/register.html.erb
@@ -1,0 +1,15 @@
+<h2>Register youtube URL of your song</h2>
+
+<%= form_with model: @song, url: :create, method: :post do |form| %>
+  <div>
+    <%= form.label :url, "URL" %><br>
+    <%= form.text_field :url %>
+  </div>
+
+  <br>
+  <div>
+    <%= form.submit "Register" %>
+  </div>
+<% end %>
+
+<%= link_to "Back to home", "/" %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -19,6 +19,9 @@
 <br>
 <%= link_to "Register a song", "/register" %>
 
+<br>
+<%= link_to "Show registered songs", "/songs" %>
+
 <script>
 
     if (navigator.geolocation) {

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -16,6 +16,9 @@
   </div>
 <% end %>
 
+<br>
+<%= link_to "Register a song", "/register" %>
+
 <script>
 
     if (navigator.geolocation) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   get "/find", to: "coordinate#find"
+  get "/register", to: "song#register"
+  post "/create", to: "song#create"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   get "/find", to: "coordinate#find"
   get "/register", to: "song#register"
   post "/create", to: "song#create"
+  get "/songs", to: "song#index"
+    
 end


### PR DESCRIPTION
# やったこと
- 楽曲登録機能追加
  - ホーム画面 => `Register a song`
  - 仮置きで座標は(50, 50)を自動登録
  - ユーザ入力は今後実装
- 登録楽曲一覧表示機能追加
  - ホーム画面 => `Show registered songs`
- 楽曲検索結果にURL表示
- 各画面にホームへ戻るボタン追加 `Back to home`

# 現在の動き

https://user-images.githubusercontent.com/34429021/148741557-37f9d729-ef9b-46b9-8f31-74b5886de470.mov


